### PR TITLE
input跟随

### DIFF
--- a/src/components/security-code/index.vue
+++ b/src/components/security-code/index.vue
@@ -129,7 +129,10 @@
   .input-code {
     position: absolute;
     left: -9999px;
-    top: -9999px;
+    width: 0;
+    height: 0;
+    opacity: 0;
+    z-index: -1;
   }
 
 </style>


### PR DESCRIPTION
只用left: -9999px; 在手机上，选中label后，虚拟按键滑出会有一个自动的聚焦跟随。top: -9999px;会使客户端虚拟按键的跟随失效。